### PR TITLE
Add JET.jl static analysis tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,34 @@
+using JET
+using FastSolvers
+using Test
+
+@testset "JET static analysis" begin
+    @testset "Package-level analysis" begin
+        rep = JET.report_package(FastSolvers; toplevel_logger = nothing)
+        @test length(JET.get_reports(rep)) == 0
+    end
+
+    @testset "SquaredExponentialKernel type stability" begin
+        kernel = SquaredExponentialKernel(0.1)
+        x_scalar = 1.0
+        y_scalar = 2.0
+        x_vec = [1.0, 2.0, 3.0]
+        y_vec = [4.0, 5.0, 6.0]
+
+        # Test kernel evaluation
+        @test_opt target_modules = (FastSolvers,) kernel(x_scalar, y_scalar)
+        @test_opt target_modules = (FastSolvers,) kernel(x_vec, y_vec)
+
+        # Test gradient operator
+        @test_opt target_modules = (FastSolvers,) kernel(x_scalar, y_scalar, ∇())
+        @test_opt target_modules = (FastSolvers,) kernel(x_vec, y_vec, ∇())
+
+        # Test Laplacian operator
+        @test_opt target_modules = (FastSolvers,) kernel(x_scalar, y_scalar, Δ())
+        @test_opt target_modules = (FastSolvers,) kernel(x_vec, y_vec, Δ())
+    end
+
+    @testset "Matern52Kernel construction" begin
+        @test_opt target_modules = (FastSolvers,) Matern52Kernel(0.1, 0.2)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,3 +26,7 @@ end
 @testset "Explicit Imports" begin
     include("explicit_imports.jl")
 end
+
+@testset "JET static analysis" begin
+    include("jet.jl")
+end


### PR DESCRIPTION
## Summary

- Added JET.jl as a test dependency
- Created `test/jet.jl` with comprehensive static analysis tests:
  - Package-level analysis to catch type errors and method ambiguities
  - Type stability tests (`@test_opt`) for `SquaredExponentialKernel` operations
  - Tests for kernel evaluation, gradient (`∇`), and Laplacian (`Δ`) operators
  - Tests for both scalar and vector inputs
- Updated `test/runtests.jl` to include the new JET test suite

The JET analysis confirms that FastSolvers.jl is already well-typed and type-stable. All existing code passes JET analysis without any issues. This PR adds test infrastructure to ensure type stability is maintained as the package evolves.

## JET Analysis Results

Running JET analysis on the package showed:
- ✅ No type instabilities detected
- ✅ No unresolved method calls
- ✅ All kernel operations return concrete types (Float64, Vector{Float64}, Matrix{Float64})

## Test plan

- [x] All existing tests pass
- [x] New JET tests pass (8 tests)
- [ ] CI checks

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)